### PR TITLE
Automatically set the API Key from a config option

### DIFF
--- a/start.php
+++ b/start.php
@@ -5,4 +5,6 @@ Autoloader::map(array(
 	'Stripe' => __DIR__.'/library/Stripe.php',
 ));
 
+Stripe::setApiKey(Config::get('stripe.api_key'));
+
 ?>


### PR DESCRIPTION
Instead of making people set the API Key, we should take advantage of config files and set it automatically every time.
